### PR TITLE
travis rates class updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ isort:
 ##	Check sorting of imports in project code using isort.
 .PHONY: isort-check 
 isort-check:
-	isort poglink tests --diff --color
+	isort poglink tests --diff --color --check
 
 ## - test
 ##	Run pytest tests.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 ##	Check linting of code with black.
 .PHONY: lint-check 
 lint-check:
-	black poglink tests --diff --color
+	black poglink tests --diff --color --check
 
 ## - isort
 ##	Automatically sort imports in project code using isort.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ all: help
 .PHONY: format 
 format: isort lint
 
+## - format-check
+##	Check (but don't apply) black linting and isort sorting.
+.PHONY: format-check 
+format-check: lint-check isort-check
+
 ## - lint
 ##	Automatically format project code with black.
 .PHONY: lint 

--- a/TODO.md
+++ b/TODO.md
@@ -28,5 +28,5 @@ server
 - [ ] In-game server notifications posted to Discord channels
 - [x] Convert to use `setup.cfg` instead of `setup.py`
 - [x] Add `old_rates` and `current_rates` to `RatesDiff` so `self.current_rates` could be used instead of `to_embed` 
-- [ ] Allow for `old_rates=old` and `new_rates=new` to be passed into `RatesStatus.to_diff()`  
+- [x] Allow for `old_rates=old` and `new_rates=new` to be passed into `RatesStatus.to_diff()`  
 - [ ] Add ability to provide custom rates URL

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,6 @@ server
 - [ ] Add auto-publish/no publish as a parameter for each cog, perhaps `auto-publish-channels = [<chan_ID1>, <chan_ID1>]`
 - [ ] In-game server notifications posted to Discord channels
 - [x] Convert to use `setup.cfg` instead of `setup.py`
-- [ ] Add `old_rates` and `current_rates` to `RatesDiff` so `self.current_rates` could be used instead of `to_embed` 
+- [x] Add `old_rates` and `current_rates` to `RatesDiff` so `self.current_rates` could be used instead of `to_embed` 
 - [ ] Allow for `old_rates=old` and `new_rates=new` to be passed into `RatesStatus.to_diff()`  
 - [ ] Add ability to provide custom rates URL

--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -143,7 +143,7 @@ class Rates(commands.Cog):
                 last_rates = RatesStatus.from_dict(last_rates_dict)
 
                 # compare rates to last rates
-                #TODO: I think this is backwards; it should be last_rates.get_diff(rates)
+                # TODO: I think this is backwards; it should be last_rates.get_diff(rates)
                 rates_diff = rates.get_diff(last_rates)
 
                 if rates_diff.items:

--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -159,7 +159,7 @@ class Rates(commands.Cog):
 
                     # generate and send embed
                     logger.info(f"Rates at {url} changed - sending embed")
-                    embed_description = rates_diff.to_embed(rates)
+                    embed_description = rates_diff.to_embed()
                     await self.send_embed(embed_description, url)
 
             await asyncio.sleep(self.polling_delay)

--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -143,8 +143,7 @@ class Rates(commands.Cog):
                 last_rates = RatesStatus.from_dict(last_rates_dict)
 
                 # compare rates to last rates
-                # TODO: I think this is backwards; it should be last_rates.get_diff(rates)
-                rates_diff = rates.get_diff(last_rates)
+                rates_diff = last_rates.get_diff(rates)
 
                 if rates_diff.items:
 

--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -143,6 +143,7 @@ class Rates(commands.Cog):
                 last_rates = RatesStatus.from_dict(last_rates_dict)
 
                 # compare rates to last rates
+                #TODO: I think this is backwards; it should be last_rates.get_diff(rates)
                 rates_diff = rates.get_diff(last_rates)
 
                 if rates_diff.items:

--- a/poglink/models/__init__.py
+++ b/poglink/models/__init__.py
@@ -1,0 +1,2 @@
+from .bans import BansPlatformPair, BansStatus, BansTimePeriodSummary
+from .rates import RatesDiff, RatesDiffItem, RatesStatus

--- a/poglink/models/bans.py
+++ b/poglink/models/bans.py
@@ -1,0 +1,117 @@
+import datetime
+import re
+from dataclasses import dataclass
+from typing import List
+
+from dateutil import parser as dateparser
+from jinja2 import Template
+
+
+@dataclass
+class BansPlatformPair:
+    platform: str
+    nbans: int
+
+    def to_dict(self):
+        return {self.platform: self.nbans}
+
+
+@dataclass
+class BansTimePeriodSummary:
+    heading: str
+    summary: List[BansPlatformPair]
+
+    def to_dict(self):
+        return {self.heading: [s.to_dict() for s in self.summary]}
+
+
+class BansStatus:
+    def __init__(
+        self,
+        bans: List[BansTimePeriodSummary],
+        last_updated: datetime.datetime = None,
+    ) -> None:
+        self.bans = bans
+        self.last_updated = (
+            dateparser.parse(last_updated)
+            if isinstance(last_updated, str)
+            else last_updated
+        )
+
+    def __eq__(self, __o: object) -> bool:
+        return self.__dict__ == __o.__dict__
+
+    @staticmethod
+    def parse_raw(raw_txt):
+        # https://regex101.com/r/KCBt9M/1
+        matches = re.findall("(.*)\n(?:=+\n)((?:.+\n)+)", raw_txt)
+
+        parsed_dict = {
+            heading: {
+                platform.strip(): int(nbans)
+                for platform, nbans in [
+                    line.split(":") for line in summary.splitlines()
+                ]
+            }
+            for heading, summary in matches
+        }
+
+        # TODO: Handle if format ever changes
+        date_string = re.search(r"Last Updated: (.*)\s.+", raw_txt).group(1)
+        last_updated = dateparser.parse(date_string)
+        return parsed_dict, last_updated
+
+    @classmethod
+    def from_raw(cls, raw_txt):
+        status_dict, last_updated = cls.parse_raw(raw_txt)
+
+        return cls.from_dict(
+            {"ban_summaries": status_dict, "last_updated": last_updated}
+        )
+
+    def to_dict(self):
+        output_dict = {
+            "last_updated": self.last_updated.isoformat(),
+            "ban_summaries": {
+                b.heading: {s.platform: s.nbans for s in b.summary} for b in self.bans
+            },
+        }
+        return output_dict
+
+    def to_raw(self):
+        return self.ban_summary_template.render(banstatus=self)
+
+    @classmethod
+    def from_dict(cls, d):
+        status_dict = d.get("ban_summaries")
+        last_updated = d.get("last_updated")
+        return cls(
+            bans=[
+                BansTimePeriodSummary(
+                    heading=period,
+                    summary=[
+                        BansPlatformPair(platform=p, nbans=n)
+                        for p, n in summary.items()
+                    ],
+                )
+                for period, summary in status_dict.items()
+            ],
+            last_updated=last_updated,
+        )
+
+    @staticmethod
+    def underline(length):
+        return "=" * length
+
+    ban_summary_template = Template(
+        """{%- for ban_timeperiod in banstatus.bans %}
+{{- ban_timeperiod.heading }}
+{% for _ in range(ban_timeperiod.heading | length) %}={% endfor %}
+{% for ban_summary in ban_timeperiod.summary %}
+{{- ban_summary.platform }}: {{ ban_summary.nbans}}
+{% endfor %}
+
+{% endfor -%}items: List[RatesDiffItem] = field(default_factory=list)
+Last Updated: {{ banstatus.last_updated.strftime('%d %b %Y %H:%M:%S') }} ET 
+"""
+    )

--- a/poglink/models/rates.py
+++ b/poglink/models/rates.py
@@ -129,19 +129,19 @@ class RatesDiff:
         )
 
     # highlights changed rates in embed
-    def to_embed(self, rates):
+    def to_embed(self):
 
-        rates_dict = rates.to_dict()
+        rates_dict = self.old.to_dict()
 
         # bold updated rates
-        updated_rates = {item.key: f"**{item.new}**" for item in self.items}
+        updated_rates = {item.key: f"**{item.new_val}**" for item in self.items}
 
         rates_dict.update(updated_rates)
 
         # rename keys and format embed description
         embed_description = "\n".join(
             [
-                f"{v.rstrip('.0')} × {rates.RATES_NAMES.get(k,k)}"
+                f"{v.rstrip('.0')} × {self.old.RATES_NAMES.get(k,k)}"
                 for k, v in rates_dict.items()
             ]
         )

--- a/poglink/models/rates.py
+++ b/poglink/models/rates.py
@@ -1,10 +1,5 @@
-import datetime
-import re
 from dataclasses import dataclass, field
 from typing import Any, List, Tuple
-
-from dateutil import parser as dateparser
-from jinja2 import Template
 
 
 class RatesStatus:
@@ -113,116 +108,6 @@ class RatesStatus:
             old=self,
             new=newrates,
         )
-
-
-@dataclass
-class BansPlatformPair:
-    platform: str
-    nbans: int
-
-    def to_dict(self):
-        return {self.platform: self.nbans}
-
-
-@dataclass
-class BansTimePeriodSummary:
-    heading: str
-    summary: List[BansPlatformPair]
-
-    def to_dict(self):
-        return {self.heading: [s.to_dict() for s in self.summary]}
-
-
-class BansStatus:
-    def __init__(
-        self,
-        bans: List[BansTimePeriodSummary],
-        last_updated: datetime.datetime = None,
-    ) -> None:
-        self.bans = bans
-        self.last_updated = (
-            dateparser.parse(last_updated)
-            if isinstance(last_updated, str)
-            else last_updated
-        )
-
-    def __eq__(self, __o: object) -> bool:
-        return self.__dict__ == __o.__dict__
-
-    @staticmethod
-    def parse_raw(raw_txt):
-        # https://regex101.com/r/KCBt9M/1
-        matches = re.findall("(.*)\n(?:=+\n)((?:.+\n)+)", raw_txt)
-
-        parsed_dict = {
-            heading: {
-                platform.strip(): int(nbans)
-                for platform, nbans in [
-                    line.split(":") for line in summary.splitlines()
-                ]
-            }
-            for heading, summary in matches
-        }
-
-        # TODO: Handle if format ever changes
-        date_string = re.search(r"Last Updated: (.*)\s.+", raw_txt).group(1)
-        last_updated = dateparser.parse(date_string)
-        return parsed_dict, last_updated
-
-    @classmethod
-    def from_raw(cls, raw_txt):
-        status_dict, last_updated = cls.parse_raw(raw_txt)
-
-        return cls.from_dict(
-            {"ban_summaries": status_dict, "last_updated": last_updated}
-        )
-
-    def to_dict(self):
-        output_dict = {
-            "last_updated": self.last_updated.isoformat(),
-            "ban_summaries": {
-                b.heading: {s.platform: s.nbans for s in b.summary} for b in self.bans
-            },
-        }
-        return output_dict
-
-    def to_raw(self):
-        return self.ban_summary_template.render(banstatus=self)
-
-    @classmethod
-    def from_dict(cls, d):
-        status_dict = d.get("ban_summaries")
-        last_updated = d.get("last_updated")
-        return cls(
-            bans=[
-                BansTimePeriodSummary(
-                    heading=period,
-                    summary=[
-                        BansPlatformPair(platform=p, nbans=n)
-                        for p, n in summary.items()
-                    ],
-                )
-                for period, summary in status_dict.items()
-            ],
-            last_updated=last_updated,
-        )
-
-    @staticmethod
-    def underline(length):
-        return "=" * length
-
-    ban_summary_template = Template(
-        """{%- for ban_timeperiod in banstatus.bans %}
-{{- ban_timeperiod.heading }}
-{% for _ in range(ban_timeperiod.heading | length) %}={% endfor %}
-{% for ban_summary in ban_timeperiod.summary %}
-{{- ban_summary.platform }}: {{ ban_summary.nbans}}
-{% endfor %}
-
-{% endfor -%}items: List[RatesDiffItem] = field(default_factory=list)
-Last Updated: {{ banstatus.last_updated.strftime('%d %b %Y %H:%M:%S') }} ET 
-"""
-    )
 
 
 @dataclass

--- a/poglink/models/rates.py
+++ b/poglink/models/rates.py
@@ -89,33 +89,15 @@ class RatesStatus:
         return "\n".join([f"{k}={v}" for k, v in self.to_dict().items()])
 
     def get_diff(self, newrates: "RatesStatus"):
-        old = self.to_dict()
-        new = newrates.to_dict()
-
-        return RatesDiff(
-            items=sorted(
-                [
-                    RatesDiffItem(
-                        key=k,
-                        old=old.get(k),
-                        new=new.get(k),
-                        extra=k not in RatesStatus.RATES_NAMES,
-                    )
-                    for k, _ in set(new.items()) - set(old.items())
-                ],
-                key=lambda x: x.key,
-            ),
-            old=self,
-            new=newrates,
-        )
+        return RatesDiff.from_statuses(self, newrates)
 
 
 @dataclass
 class RatesDiffItem:
     key: str
-    old: Any
-    new: Any
-    extra: bool = False
+    old_val: Any
+    new_val: Any
+    is_extra: bool = False
 
 
 @dataclass
@@ -134,9 +116,9 @@ class RatesDiff:
                 [
                     RatesDiffItem(
                         key=k,
-                        old=old_dict.get(k),
-                        new=new_dict.get(k),
-                        extra=k not in RatesStatus.RATES_NAMES,
+                        old_val=old_dict.get(k),
+                        new_val=new_dict.get(k),
+                        is_extra=k not in RatesStatus.RATES_NAMES,
                     )
                     for k, _ in set(new_dict.items()) - set(old_dict.items())
                 ],

--- a/poglink/models/rates.py
+++ b/poglink/models/rates.py
@@ -66,7 +66,7 @@ class RatesStatus:
 
         return cls(**expected, **extras)
 
-    def update(self, vals, raw=False):
+    def update_vals(self, vals, raw=False):
 
         parsed_vals = self.parse_raw(vals) if raw else vals
 

--- a/poglink/models/rates.py
+++ b/poglink/models/rates.py
@@ -141,7 +141,7 @@ class RatesDiff:
         # rename keys and format embed description
         embed_description = "\n".join(
             [
-                f"{v.rstrip('.0')} × {self.old.RATES_NAMES.get(k,k)}"
+                f"{v.rstrip('.0')} × {self.old.RATES_NAMES.get(k,k)}"  # TODO: rstrip won't remove '.0' if wrapped in ** from above
                 for k, v in rates_dict.items()
             ]
         )

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 black==20.8b1
 build==0.7.0
+colorama==0.4.4
 isort==5.10.1
 pytest-asyncio==0.16.0
 pytest-httpserver==1.0.2

--- a/tests/unit/test_models_rates.py
+++ b/tests/unit/test_models_rates.py
@@ -69,49 +69,49 @@ def rates_update_dict():
     }
 
 
-def test_parse_rates(sample_rates_txt):
+def test_rates_staticmethod_parse_raw(sample_rates_txt):
     d = RatesStatus.parse_raw(sample_rates_txt)
 
     assert d.get("TamingSpeedMultiplier") == "3.0"
     assert d.get("HexagonRewardMultiplier") == "1.5"
 
 
-def test_from_raw(sample_rates_txt):
+def test_rates_classmethod_from_raw(sample_rates_txt):
     rates = RatesStatus.from_raw(sample_rates_txt)
     assert rates.MatingIntervalMultiplier == "0.6"
     assert rates.BabyCuddleIntervalMultiplier == "0.6"
     assert rates.extras == {"MyMadeUpValue": "69420"}
 
 
-def test_from_dict(sample_rates_dict):
+def test_rates_classmethod_from_dict(sample_rates_dict):
     rates = RatesStatus.from_dict(sample_rates_dict)
     assert rates.MatingIntervalMultiplier == "0.6"
     assert rates.BabyCuddleIntervalMultiplier == "0.6"
     assert rates.extras == {"MyMadeUpValue": "69420"}
 
 
-def test_update_from_raw(sample_rates_txt, rates_update_txt):
+def test_rates_method_update_raw(sample_rates_txt, rates_update_txt):
     rates = RatesStatus.from_raw(sample_rates_txt)
     assert rates.XPMultiplier == "3.0"
     assert rates.extras == {"MyMadeUpValue": "69420"}
 
-    rates.update(rates_update_txt, raw=True)
+    rates.update_vals(rates_update_txt, raw=True)
 
     assert rates.XPMultiplier == "2.0"
     assert rates.extras == {"MyMadeUpValue": "42069", "MyOtherMadeUpValue": "42069"}
 
 
-def test_update_from_dict(sample_rates_dict, rates_update_dict):
+def test_rates_method_update_dict(sample_rates_dict, rates_update_dict):
     rates = RatesStatus.from_dict(sample_rates_dict)
     assert rates.XPMultiplier == "3.0"
 
-    rates.update(rates_update_dict, raw=False)
+    rates.update_vals(rates_update_dict, raw=False)
 
     assert rates.XPMultiplier == "2.0"
     assert rates.extras == {"MyMadeUpValue": "42069", "MyOtherMadeUpValue": "42069"}
 
 
-def test_get_expected_and_extras(sample_rates_dict):
+def test_rates_staticmethod_get_expected_and_extras(sample_rates_dict):
     expected, extras = RatesStatus.get_expected_and_extras(sample_rates_dict)
 
     assert expected == {
@@ -131,19 +131,19 @@ def test_get_expected_and_extras(sample_rates_dict):
     }
 
 
-def test_to_raw(sample_rates_dict, sample_rates_txt):
+def test_rates_method_to_raw(sample_rates_dict, sample_rates_txt):
     rates = RatesStatus.from_dict(sample_rates_dict)
 
     assert rates.to_raw() == sample_rates_txt
 
 
-def test_to_dict(sample_rates_dict, sample_rates_txt):
+def test_rates_method_to_dict(sample_rates_dict, sample_rates_txt):
     rates = RatesStatus.from_raw(sample_rates_txt)
 
     assert rates.to_dict() == sample_rates_dict
 
 
-def test_get_diff(sample_rates_dict):
+def test_rates_method_get_diff(sample_rates_dict):
     rates = RatesStatus.from_dict(sample_rates_dict)
 
     sample_rates_dict["BabyMatureSpeedMultiplier"] = "4.2"
@@ -178,7 +178,7 @@ def test_get_diff(sample_rates_dict):
     assert diff == RatesDiff(old=rates, new=rates_copy)
 
 
-def test_rates_comparison(sample_rates_dict, sample_rates_txt):
+def test_rates_eq(sample_rates_dict, sample_rates_txt):
     rates_from_dict = RatesStatus.from_dict(sample_rates_dict)
     rates_from_txt = RatesStatus.from_raw(sample_rates_txt)
 

--- a/tests/unit/test_models_rates.py
+++ b/tests/unit/test_models_rates.py
@@ -156,10 +156,16 @@ def test_get_diff(sample_rates_dict):
     assert diff == RatesDiff(
         items=[
             RatesDiffItem(
-                key="BabyMatureSpeedMultiplier", old="3.0", new="4.2", extra=False
+                key="BabyMatureSpeedMultiplier",
+                old_val="3.0",
+                new_val="4.2",
+                is_extra=False,
             ),
             RatesDiffItem(
-                key="CompletelyRandomNewThing", old=None, new="2.2", extra=True
+                key="CompletelyRandomNewThing",
+                old_val=None,
+                new_val="2.2",
+                is_extra=True,
             ),
         ],
         old=rates,

--- a/tests/unit/test_models_rates.py
+++ b/tests/unit/test_models_rates.py
@@ -161,13 +161,15 @@ def test_get_diff(sample_rates_dict):
             RatesDiffItem(
                 key="CompletelyRandomNewThing", old=None, new="2.2", extra=True
             ),
-        ]
+        ],
+        old=rates,
+        new=newrates,
     )
 
     rates_copy = copy.deepcopy(rates)
     diff = rates.get_diff(rates_copy)
 
-    assert diff == RatesDiff()
+    assert diff == RatesDiff(old=rates, new=rates_copy)
 
 
 def test_rates_comparison(sample_rates_dict, sample_rates_txt):

--- a/tests/unit/test_models_rates.py
+++ b/tests/unit/test_models_rates.py
@@ -184,6 +184,7 @@ def test_rates_eq(sample_rates_dict, sample_rates_txt):
 
     assert rates_from_dict == rates_from_txt
 
+
 def test_rates_method_to_embed(sample_rates_dict):
     old_rates = RatesStatus.from_dict(sample_rates_dict)
     sample_rates_dict["XPMultiplier"] = 1.0
@@ -203,5 +204,5 @@ def test_rates_method_to_embed(sample_rates_dict):
 3 × Imprinting
 1.5 × Hexagon Reward
 6942 × MyMadeUpValue\
-""" 
+"""
     assert rates_diff.to_embed() == highlighted_embed

--- a/tests/unit/test_models_rates.py
+++ b/tests/unit/test_models_rates.py
@@ -2,7 +2,7 @@ import copy
 
 import pytest
 
-from poglink.models import RatesDiff, RatesDiffItem, RatesStatus
+from poglink.models import RatesDiff, RatesDiffItem, RatesStatus, rates
 
 
 @pytest.fixture()
@@ -183,3 +183,25 @@ def test_rates_eq(sample_rates_dict, sample_rates_txt):
     rates_from_txt = RatesStatus.from_raw(sample_rates_txt)
 
     assert rates_from_dict == rates_from_txt
+
+def test_rates_method_to_embed(sample_rates_dict):
+    old_rates = RatesStatus.from_dict(sample_rates_dict)
+    sample_rates_dict["XPMultiplier"] = 1.0
+    sample_rates_dict["MatingIntervalMultiplier"] = 1.0
+    new_rates = RatesStatus.from_dict(sample_rates_dict)
+
+    rates_diff = RatesDiff.from_statuses(old=old_rates, new=new_rates)
+
+    highlighted_embed = """\
+3 × Taming
+3 × Harvesting
+**1.0** × XP
+**1.0** × Mating Interval
+3 × Maturation
+3 × Hatching
+0.6 × Cuddle Interval
+3 × Imprinting
+1.5 × Hexagon Reward
+6942 × MyMadeUpValue\
+""" 
+    assert rates_diff.to_embed() == highlighted_embed


### PR DESCRIPTION
Overview
------------
This PR primarily introduces some changes to the `RatesDiff` class to address Issue #24. It also splits out the rates and bans models into their own modules for better organization.

Ideally should be merged after PR #22.
 
Commit Summary
--------------------------
- feat: Add old and new attributes to RatesDiff
- docs: Update todo
- fix: create models subpackage and split models into separate modules
- fix: Simplify get_diff() method
- update todo
- test: Rename rates unit tests
- add todo
