### PR TITLE
build: Provide setup script for running as a systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Recently updated rates will be shown in **bold**, and the embed title will be au
 - [Prerequisites](https://github.com/FM-17/poglink/blob/main/docs/prerequisites.md)
 - [Running natively in Python](https://github.com/FM-17/poglink/blob/main/docs/native-installation.md)
 - [Running within Docker container](https://github.com/FM-17/poglink/blob/main/docs/docker-installation.md)
+- [Installing as a `systemd` Service](https://github.com/FM-17/poglink/blob/main/docs/systemd-installation.md)
 - [Configuration](https://github.com/FM-17/poglink/blob/main/docs/configuration.md)
 
 ## Future updates

--- a/docs/docker-installation.md
+++ b/docs/docker-installation.md
@@ -36,4 +36,6 @@ If you choose to use `docker-compose`, the bot can be started by navigating to t
 docker-compose up
 ```
 
+Note: If you wish for the container to automatically restart after a reboot or unexpected crash, add `restart: unless-stopped` to the `bot` service defined above.
+
 >📝 Learn more about `docker-compose` [here](https://docs.docker.com/compose/)

--- a/docs/systemd-installation.md
+++ b/docs/systemd-installation.md
@@ -1,0 +1,65 @@
+# Running as a `systemd` Service
+
+## Installation
+A script has been provided to assist in the installation process.
+
+### Download
+First, clone the project repository to some location of your choice:
+```bash
+git clone https://github.com/FM-17/poglink.git
+cd {cloned repo location}/poglink
+```
+
+### (Optional) Creating a virtual environment
+The installation script installs the `poglink` Python package in the Python environment that is currently active in the shell when the script is executed. It is highly recommended to use a virtual environment to install `poglink`. The script will warn you of this and subsequently exit unless `FORCE=true` is set before executing. 
+
+To create and activate a new virtual environment (Python 3.7+), run the following commands:
+```bash
+cd <path to desired virtual env location>
+python3 -m  venv venv    # Create a virtual environment named 'venv'
+source venv/bin/activate # Activate the newly created virtual environment
+```
+
+### Running the Install Script
+To begin the installation, ensure the script is executable then run:
+```bash
+chmod +x scripts/install-service.sh
+# export DATA_DIR=<path to desired data directory> # Optional
+scripts/install-service.sh
+```
+The script will do several things:
+- Install `poglink` to the current Python environment
+- Create a `systemd` service definition to execute `poglink`
+- Check for a configuration file at the location specified by `DATA_DIR` (default `~/.poglink`); If not found, one will be created from sample values.
+
+### Re-running the Install Script
+The installation script can be run again to reinstall the service. This can be helpful when trying to change the default data directory, or the Python environment being used. 
+
+When installing again, the `systemd` service file will be overwritten. A backup will be created at `/etc/systemd/system/poglink.service.bak`.
+
+
+## Uninstalling
+The service can be uninstalled via:
+```bash
+# Stop service and prevent from restarting
+sudo systemctl stop poglink
+sudo systemctl disable poglink
+
+# Remove service definition and reload systemd
+sudo rm -f /etc/systemd/system/poglink.service
+sudo systemctl daemon-reload
+
+# (Optional) Remove Python package
+# pip uninstall poglink
+# 
+# or
+#
+# rm -rf <path/to/venv>
+```
+
+## Some Notes About the Service
+1. When enabled, the service will restart on failures and on reboots. 
+2. If the program crashes, it will wait 5 seconds before restarting to prevent runaway in the case of persistent errors.
+3. If the program restarts more than 4 times in a 30 second period, it must be restarted again via `sudo systemctl start poglink` or by rebooting.
+4. To modify any of the behaviour of the service after installation, edit the file at `/etc/system/systemd/poglink.service`.
+5. To monitor real-time program logs from the service, execute `journalctl -fu poglink`. 

--- a/resources/poglink.service
+++ b/resources/poglink.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Runs Poglink bot as a system service.
+
+[Service]
+Type=simple
+ExecStart=##PYTHON## -m poglink.main
+
+[Install]
+WantedBy=multi-user.target

--- a/resources/poglink.service
+++ b/resources/poglink.service
@@ -5,7 +5,7 @@ StartLimitBurst=4
 
 [Service]
 Type=simple
-Environment=DATA_DIR=##DATA_DIR##
+Environment=BOT_DATA_DIR=##DATA_DIR##
 ExecStart=##PYTHON## -m poglink.main
 Restart=on-failure
 RestartSec=5

--- a/resources/poglink.service
+++ b/resources/poglink.service
@@ -1,9 +1,15 @@
 [Unit]
 Description=Runs Poglink bot as a system service.
+StartLimitIntervalSec=30
+StartLimitBurst=4
 
 [Service]
 Type=simple
+Environment=DATA_DIR=##DATA_DIR##
 ExecStart=##PYTHON## -m poglink.main
+Restart=on-failure
+RestartSec=5
+User=##USER##
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e 
+
+# Change to script directory for predictable behaviour
+cd "$(dirname "$0")"
+
+# Check whether virtual environment is active
+if [ -z "${VIRTUAL_ENV}" ] && [ "${FORCE}" != "true"  ]; then
+    echo "Warning: Virtual environment not detected! It is highly recommended to install this program to run under a virtual environment. Please activate your virtual environment and run this script again."
+    echo "If you're certain you'd like to continue without a virtual environment, you can run again with 'FORCE=true'." 
+    exit 1
+fi
+
+# Install poglink python package
+pip install poglink
+
+# Obtain path to python executable
+if [ -z "${VIRTUAL_ENV}" ]; then
+    PYTHON_EXECUTABLE="$(which python3)"
+else 
+    PYTHON_EXECUTABLE="${VIRTUAL_ENV}/bin/python3"
+fi 
+
+echo "Configuring service to run with ${PYTHON_EXECUTABLE}"
+
+# Copy service file into place
+OUTPUT_PATH=/etc/systemd/system/poglink.service
+
+sudo install \
+    -v \
+    --backup \
+    --suffix .bak \
+    ../resources/poglink.service \
+    ${OUTPUT_PATH}
+
+# TODO: Copy sample config to ~/.poglink if it doesn't exist yet
+
+# Replace python executable text in service file
+sudo sed -i "s@\#\#PYTHON\#\#@${PYTHON_EXECUTABLE}@g" "${OUTPUT_PATH}"
+
+# Reload systemd daemon
+sudo systemctl daemon-reload 
+
+# Enable service
+sudo systemctl enable poglink 
+
+echo "Start service by running 'sudo systemctl start poglink'. Monitor logs via 'journalctl -fu poglink'."
+    

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e 
 
+# Define data directory to be used for application config file.
+DATA_DIR=${DATA_DIR:-${HOME}/.poglink}
+
 # Change to script directory for predictable behaviour
 cd "$(dirname "$0")"
 
@@ -16,27 +19,40 @@ pip install poglink
 
 # Obtain path to python executable
 if [ -z "${VIRTUAL_ENV}" ]; then
+    echo -e "\n\nVirtual environment not detected."
     PYTHON_EXECUTABLE="$(which python3)"
 else 
+    echo -e "\n\nVirtual environment detected."
     PYTHON_EXECUTABLE="${VIRTUAL_ENV}/bin/python3"
 fi 
 
 echo "Configuring service to run with ${PYTHON_EXECUTABLE}"
 
-# Copy service file into place
-OUTPUT_PATH=/etc/systemd/system/poglink.service
+# Disable service if currently running from a previous installation
+SERVICE_FILE_PATH=/etc/systemd/system/poglink.service
+sudo systemctl stop "$SERVICE_FILE_PATH" || true
 
+# Copy service file into place
 sudo install \
     -v \
     --backup \
     --suffix .bak \
     ../resources/poglink.service \
-    ${OUTPUT_PATH}
+    ${SERVICE_FILE_PATH}
 
-# TODO: Copy sample config to ~/.poglink if it doesn't exist yet
+# Replace values in service file
+sudo sed -i "s@\#\#PYTHON\#\#@${PYTHON_EXECUTABLE}@g" "${SERVICE_FILE_PATH}"
+sudo sed -i "s@\#\#DATA_DIR\#\#@${DATA_DIR}@g" "${SERVICE_FILE_PATH}"
+sudo sed -i "s@\#\#USER\#\#@${USER}@g" "${SERVICE_FILE_PATH}"
 
-# Replace python executable text in service file
-sudo sed -i "s@\#\#PYTHON\#\#@${PYTHON_EXECUTABLE}@g" "${OUTPUT_PATH}"
+# Copy sample config to ${DATA_DIR} if it doesn't exist yet
+if [ ! -e ${DATA_DIR}/config.yaml ]; then  
+    echo "Poglink config not found in $DATA_DIR; Using creating from sample..."
+    mkdir -p ${DATA_DIR}
+    cp ../sample-config.yaml ${DATA_DIR}/config.yaml
+
+    echo -e "\n\nIMPORTANT!!! A sample configuration file has been created at ${DATA_DIR}/config.yaml . Please edit this file before starting the application for the first time."
+fi
 
 # Reload systemd daemon
 sudo systemctl daemon-reload 
@@ -44,5 +60,7 @@ sudo systemctl daemon-reload
 # Enable service
 sudo systemctl enable poglink 
 
-echo "Start service by running 'sudo systemctl start poglink'. Monitor logs via 'journalctl -fu poglink'."
-    
+echo -e "\n\nThe Poglink service has been enabled to start at boot." 
+echo "Start the service now by running 'sudo systemctl start poglink'."
+echo "Monitor logs via 'journalctl -fu poglink'."
+echo "To stop the service, run `sudo systemctl stop poglink`. To prevent from starting at boot, run `sudo systemctl disable poglink`."


### PR DESCRIPTION
I've created a script which I think will walk the user through the process of installing as a service. I've tested a few times in several variations on my machine and it seems to work great, so I think it's good to include.