### PR TITLE
travis rates urls

### DIFF
--- a/poglink/bot.py
+++ b/poglink/bot.py
@@ -5,6 +5,7 @@ import yaml
 from discord.ext import commands
 
 from poglink.config import LIST_VALUES
+from poglink.error import ConfigReadError
 from poglink.utils import parse_list
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ class BotConfig:
                 logger.error(
                     f"Could not read config file at specified location: {config_path}"
                 )
-                raise Exception(f"Could not read file at {fullpath}")
+                raise ConfigReadError(f"Could not read file at {fullpath}")
         else:
             logger.error(f"File does not exist at location: {fullpath}")
             raise FileNotFoundError("File does not exist at location")

--- a/poglink/bot.py
+++ b/poglink/bot.py
@@ -24,8 +24,10 @@ class BotConfig:
         self.rates_channel_id = rates_channel_id
         self.bans_channel_id = bans_channel_id
         self.polling_delay = polling_delay
-        self.allowed_roles = allowed_roles
-        self.rates_urls = rates_urls
+        self.allowed_roles = (
+            [allowed_roles] if isinstance(allowed_roles, str) else allowed_roles
+        )
+        self.rates_urls = [rates_urls] if isinstance(rates_urls, str) else rates_urls
         # self.bans_url = bans_url
         self.data_dir = data_dir
 

--- a/poglink/bot.py
+++ b/poglink/bot.py
@@ -34,6 +34,9 @@ class BotConfig:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+    def __eq__(self, __o: object) -> bool:
+        return self.__dict__ == __o.__dict__
+
     @classmethod
     def from_dict(cls, d):
         return cls(**d)

--- a/poglink/bot.py
+++ b/poglink/bot.py
@@ -4,6 +4,9 @@ import os
 import yaml
 from discord.ext import commands
 
+from poglink.config import LIST_VALUES
+from poglink.utils import parse_list
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,12 +27,20 @@ class BotConfig:
         self.rates_channel_id = rates_channel_id
         self.bans_channel_id = bans_channel_id
         self.polling_delay = polling_delay
-        self.allowed_roles = (
-            [allowed_roles] if isinstance(allowed_roles, str) else allowed_roles
-        )
-        self.rates_urls = [rates_urls] if isinstance(rates_urls, str) else rates_urls
+        self.allowed_roles = allowed_roles
+        self.rates_urls = rates_urls
         # self.bans_url = bans_url
         self.data_dir = data_dir
+
+        # handle special cases for list parsing
+        for val in LIST_VALUES:
+            if isinstance(getattr(self, val), str):
+                try:
+                    setattr(self, val, parse_list(getattr(self, val)))
+                except TypeError as e:
+                    logger.warning(
+                        f"Incorrect variable format for {val}; should be comma separated list. Actual value: {config[val]}; {e}"
+                    )
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/poglink/config.py
+++ b/poglink/config.py
@@ -3,6 +3,7 @@ import os
 
 import yaml
 
+from poglink.error import ConfigReadError
 from poglink.utils import parse_list
 
 logger = logging.getLogger(__name__)
@@ -41,8 +42,12 @@ def setup_config(args, default_config=DEFAULT_CONFIG):
     logger.debug(f"Setting up configuration. Checking for config file: {config_path}")
 
     if os.path.exists(config_path):
-        with open(os.path.expanduser(config_path)) as f:
-            config_from_file = yaml.safe_load(f)
+        try:
+            with open(os.path.expanduser(config_path)) as f:
+                config_from_file = yaml.safe_load(f)
+        except Exception as e:
+            logger.error(f"Problem reading configuration file at {config_path}: {e}")
+            raise ConfigReadError(e) from e
     else:
         logger.warning(
             f"No configuration file found at {config_path}. Configuration must be set via CLI args or environment variables."

--- a/poglink/error.py
+++ b/poglink/error.py
@@ -8,3 +8,7 @@ class RatesFetchError(Exception):
 
 class RatesProcessError(Exception):
     pass
+
+
+class ConfigReadError(Exception):
+    pass

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -7,6 +7,8 @@ rates_channel_id: <channel to post rates in>
 
 # OPTIONAL
 polling_delay: 60
-allowed_roles: <roles permitted to use bot commands>
-rates_urls: "http://arkdedicated.com/dynamicconfig.ini"
+allowed_roles: 
+  - <roles permitted to use bot commands>
+rates_urls: 
+  - "http://arkdedicated.com/dynamicconfig.ini"
 # bans_url: "http://arkdedicated.com/bansummary.txt" # TODO: Reimplement when bans are enabled

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,11 @@ def sample_application_config_comma_yaml():
 
 
 @pytest.fixture
+def application_config_broken():
+    return "tests/data/application-config-broken.yaml"
+
+
+@pytest.fixture
 def sample_application_config_json():
     return "tests/data/application-config-1.json"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def sample_dynamicconfig_2():
 def sample_application_config_yaml():
     return "tests/data/application-config-1.yaml"
 
+
 @pytest.fixture
 def sample_application_config_comma_yaml():
     return "tests/data/application-config-2.yaml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,10 @@ def sample_dynamicconfig_2():
 def sample_application_config_yaml():
     return "tests/data/application-config-1.yaml"
 
+@pytest.fixture
+def sample_application_config_comma_yaml():
+    return "tests/data/application-config-2.yaml"
+
 
 @pytest.fixture
 def sample_application_config_json():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,16 @@ def sample_dynamicconfig_2():
 
 
 @pytest.fixture
+def sample_application_config_yaml():
+    return "tests/data/application-config-1.yaml"
+
+
+@pytest.fixture
+def sample_application_config_json():
+    return "tests/data/application-config-1.json"
+
+
+@pytest.fixture
 def last_rates():
     shutil.copy(SAMPLE_DYNAMICCONFIG_PATH_1, LAST_DYNAMICCONFIG_PATH)
     with open(LAST_DYNAMICCONFIG_PATH) as f:

--- a/tests/data/application-config-1.json
+++ b/tests/data/application-config-1.json
@@ -1,0 +1,12 @@
+{
+  "token": "abcd",
+  "rates_channel_id": "1234",
+  "polling_delay": 60,
+  "allowed_roles": [
+    "admin",
+    "regular_users"
+  ],
+  "rates_urls": [
+    "http://arkdedicated.com/dynamicconfig.ini"
+  ]
+}

--- a/tests/data/application-config-1.yaml
+++ b/tests/data/application-config-1.yaml
@@ -1,0 +1,8 @@
+token: abcd
+rates_channel_id: "1234"
+polling_delay: 60
+allowed_roles: 
+  - admin
+  - regular_users
+rates_urls: 
+  - "http://arkdedicated.com/dynamicconfig.ini"

--- a/tests/data/application-config-2.yaml
+++ b/tests/data/application-config-2.yaml
@@ -1,0 +1,5 @@
+token: abcd
+rates_channel_id: "1234"
+polling_delay: 60
+allowed_roles: admin,regular_users
+rates_urls: "http://arkdedicated.com/dynamicconfig.ini,http://www.google.com"

--- a/tests/data/application-config-broken.yaml
+++ b/tests/data/application-config-broken.yaml
@@ -1,0 +1,5 @@
+token: abcd
+rates_channel_id: "1234"
+polling_delay: 60
+allowed_roles: "admin","regular_users"
+rates_urls: "http://arkdedicated.com/dynamicconfig.ini,http://www.google.com"

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -72,3 +72,12 @@ def test_configurable_bot(sample_config_dict):
     assert bot.config.allowed_roles == ["admin"]
     assert bot.config.rates_urls == ["www.arkrates.com"]
     assert bot.config.data_dir == "/my/fake/dir"
+
+
+def test_comma_separation(sample_application_config_comma_yaml):
+    botconfig = BotConfig.from_file(sample_application_config_comma_yaml)
+    assert botconfig.allowed_roles == ["admin", "regular_users"]
+    assert botconfig.rates_urls == [
+        "http://arkdedicated.com/dynamicconfig.ini",
+        "http://www.google.com",
+    ]

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 
 from poglink.bot import BotConfig, ConfigurableBot
+from poglink.error import ConfigReadError
 
 
 @pytest.fixture
@@ -82,3 +83,8 @@ def test_comma_separation(sample_application_config_comma_yaml):
         "http://arkdedicated.com/dynamicconfig.ini",
         "http://www.google.com",
     ]
+
+
+def test_config_read_error(application_config_broken):
+    with pytest.raises(ConfigReadError):
+        botconfig = BotConfig.from_file(application_config_broken)

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -1,0 +1,62 @@
+import copy
+
+import pytest
+
+from poglink.bot import BotConfig, ConfigurableBot
+
+
+@pytest.fixture
+def sample_config():
+    return {
+        "token": "abcd",
+        "rates_channel_id": "1234",
+        "bans_channel_id": "4321",
+        "polling_delay": 69,
+        "allowed_roles": ["admin"],
+        "rates_urls": ["www.arkrates.com"],
+        "data_dir": "/my/fake/dir",
+    }
+
+
+@pytest.fixture
+def sample_config_singular(sample_config):
+    config = copy.deepcopy(sample_config)
+    config.update({"allowed_roles": "regular_user", "rates_urls": "www.google.com"})
+    return config
+
+
+def test_botconfig_from_dict(sample_config):
+    botconfig = BotConfig.from_dict(sample_config)
+
+    assert botconfig.token == "abcd"
+    assert botconfig.rates_channel_id == "1234"
+    assert botconfig.bans_channel_id == "4321"
+    assert botconfig.polling_delay == 69
+    assert botconfig.allowed_roles == ["admin"]
+    assert botconfig.rates_urls == ["www.arkrates.com"]
+    assert botconfig.data_dir == "/my/fake/dir"
+
+
+def test_botconfig_singular_vals(sample_config_singular):
+    botconfig = BotConfig.from_dict(sample_config_singular)
+
+    assert botconfig.allowed_roles == ["regular_user"]
+    assert botconfig.rates_urls == ["www.google.com"]
+
+
+def test_botconfig_from_file(
+    sample_application_config_yaml, sample_application_config_json
+):
+    botconfig_yaml = BotConfig.from_file(sample_application_config_yaml)
+    botconfig_json = BotConfig.from_file(sample_application_config_json)
+
+    # YAML and JSON formats both equivalent
+    assert botconfig_yaml == botconfig_json
+
+    # Expected values are present
+    assert botconfig_yaml.token == "abcd"
+    assert botconfig_yaml.rates_channel_id == "1234"
+    assert botconfig_yaml.polling_delay == 60
+    assert botconfig_yaml.allowed_roles == ["admin", "regular_users"]
+    assert botconfig_yaml.rates_urls == ["http://arkdedicated.com/dynamicconfig.ini"]
+    assert botconfig_yaml.data_dir == None

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -6,7 +6,7 @@ from poglink.bot import BotConfig, ConfigurableBot
 
 
 @pytest.fixture
-def sample_config():
+def sample_config_dict():
     return {
         "token": "abcd",
         "rates_channel_id": "1234",
@@ -19,14 +19,14 @@ def sample_config():
 
 
 @pytest.fixture
-def sample_config_singular(sample_config):
-    config = copy.deepcopy(sample_config)
+def sample_config_dict_singular(sample_config_dict):
+    config = copy.deepcopy(sample_config_dict)
     config.update({"allowed_roles": "regular_user", "rates_urls": "www.google.com"})
     return config
 
 
-def test_botconfig_from_dict(sample_config):
-    botconfig = BotConfig.from_dict(sample_config)
+def test_botconfig_from_dict(sample_config_dict):
+    botconfig = BotConfig.from_dict(sample_config_dict)
 
     assert botconfig.token == "abcd"
     assert botconfig.rates_channel_id == "1234"
@@ -37,8 +37,8 @@ def test_botconfig_from_dict(sample_config):
     assert botconfig.data_dir == "/my/fake/dir"
 
 
-def test_botconfig_singular_vals(sample_config_singular):
-    botconfig = BotConfig.from_dict(sample_config_singular)
+def test_botconfig_singular_vals(sample_config_dict_singular):
+    botconfig = BotConfig.from_dict(sample_config_dict_singular)
 
     assert botconfig.allowed_roles == ["regular_user"]
     assert botconfig.rates_urls == ["www.google.com"]
@@ -60,3 +60,15 @@ def test_botconfig_from_file(
     assert botconfig_yaml.allowed_roles == ["admin", "regular_users"]
     assert botconfig_yaml.rates_urls == ["http://arkdedicated.com/dynamicconfig.ini"]
     assert botconfig_yaml.data_dir == None
+
+
+def test_configurable_bot(sample_config_dict):
+    bot = ConfigurableBot(command_prefix=".test", config_dict=sample_config_dict)
+
+    assert bot.config.token == "abcd"
+    assert bot.config.rates_channel_id == "1234"
+    assert bot.config.bans_channel_id == "4321"
+    assert bot.config.polling_delay == 69
+    assert bot.config.allowed_roles == ["admin"]
+    assert bot.config.rates_urls == ["www.arkrates.com"]
+    assert bot.config.data_dir == "/my/fake/dir"

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -76,6 +76,7 @@ def test_configurable_bot(sample_config_dict):
 
 def test_comma_separation(sample_application_config_comma_yaml):
     botconfig = BotConfig.from_file(sample_application_config_comma_yaml)
+
     assert botconfig.allowed_roles == ["admin", "regular_users"]
     assert botconfig.rates_urls == [
         "http://arkdedicated.com/dynamicconfig.ini",


### PR DESCRIPTION
Fixes #42. Should be merged after #40 

Comma-separated lists were handled in the `poglink.utils.setup_config` function which is being used in the `main.py` module right now, but the same level of type-checking/parsing wasn't being done for arguments passed directly to the `BotConfig` class for instantiation.

- fix: Ensure certain BotConfig vals passed as strings are cast to length-1 lists
- test: Add some tests for BotConfig
- test: Add another test for bot instantiation
- fix: Parse comma separated list types in BotConfig instantiation
