### PR TITLE
fix: Add util for rotating file

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+
+import pytest
+
+from poglink.utils import rotate_backups
+
+
+@pytest.fixture(scope="module")
+def tmpdir():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
+
+
+@pytest.fixture
+def main_filename(tmpdir):
+    filename = os.path.join(tmpdir, "file.txt")
+    return filename
+
+
+def test_rotate_backup(tmpdir, main_filename):
+    # Starting with empty directory
+    assert len(os.listdir(tmpdir)) == 0
+
+    # Check single file is rotated
+    with open(os.path.join(tmpdir, "file.txt"), "w") as f:
+        f.write("2")
+    rotate_backups(main_filename, 3)
+    assert ["file.txt.1"] == os.listdir(tmpdir)
+
+    # Check two files are rotated
+    with open(os.path.join(tmpdir, "file.txt"), "w") as f:
+        f.write("2")
+    rotate_backups(main_filename, 3)
+    assert {"file.txt.2", "file.txt.1"} == set(os.listdir(tmpdir))
+
+    # Check 3rd file is discarded
+    with open(os.path.join(tmpdir, "file.txt"), "w") as f:
+        f.write("3")
+    rotate_backups(main_filename, 3)
+    assert {"file.txt.2", "file.txt.1"} == set(os.listdir(tmpdir))
+
+    # Check that rotation still works without base file
+    rotate_backups(main_filename, 3)
+    assert ["file.txt.2"] == os.listdir(tmpdir)
+    with open(os.path.join(tmpdir, "file.txt.2")) as f:
+        assert "3" == f.read()


### PR DESCRIPTION
Utility function update to make it easier to save more than one copy of locally cached server rates.

Suggestion:
- Wherever server rates are written to disk, call `rotate_backups()` on the filename just before writing the new version. Note you may have to change when rates are written to disk, as I think you might now need to write to disk now even when rates haven't changed. 
- When comparing rates and determining whether or not to notify via discord, check the following conditions (ignore pseudocode):
```
last_rates.1.json != last_rates.json # 1. previous two cached rates are different from one another
current_rates == last_rates.json # 2. current rates have remained constant for at least one full polling period
```