### PR TITLE
CI Quick Fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           cache-dependency-path: |
             setup.py
             requirements.dev.txt
-      - run: pip install -r requirements.dev.txt -e . 
+      - run: pip install -r requirements.dev.txt .
       - run: make test-cov
       - uses: codecov/codecov-action@v2 
 

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ isort-check:
 ##	Run pytest tests.
 .PHONY: test 
 test:
-	pytest
+	python -m pytest
 
 ## - test-cov
 ##	Run pytest tests with coverage report.
 .PHONY: test-cov
 test-cov:
-	pytest --cov=poglink --cov-report=xml:coverage.xml
+	python -m pytest --cov=poglink --cov-report=xml:coverage.xml
 	@coverage report
 	@coverage html
 


### PR DESCRIPTION
Reverts last commit which changed CI config to install poglink in development mode in order to collect proper coverage stats. By running `pytest` via `python -m pytest`, the [current directory is added to the python path](https://docs.pytest.org/en/latest/how-to/usage.html#calling-pytest-through-python-m-pytest), and so the `poglink` imports in the tests actually use the correct files that are being monitored by `coverage.py`.

