### PR TITLE
ci: Split dev version publishing into separate CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,36 +70,6 @@ jobs:
     outputs:
       package_version: ${{ steps.semantic_release.outputs.new_release_version }}
 
-  publish-non-release-python:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    outputs:
-        package_version: ${{ steps.set-output-step.outputs.package_version }}
-    steps:
-      - uses: actions/checkout@v2.4.0
-        with:
-          fetch-depth: 0  # https://github.com/pypa/setuptools_scm/issues/480
-      - uses: actions/setup-python@v2.3.1
-        with:  
-          python-version: 3.7
-          cache: 'pip'
-          cache-dependency-path: |
-            setup.py
-            requirements.dev.txt
-      - run: pip install -r requirements.dev.txt .
-      - name: Build non-release
-        run: |
-          make python-build
-      - id: set-output-step
-        run: |
-          PACKAGE_VERSION=$(python3 -c 'from setuptools_scm import get_version; print(get_version(local_scheme="no-local-version"))' || echo 0.0.1.dev0)
-          echo "::set-output name=package_version::${PACKAGE_VERSION}"
-      - name: Publish to pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-
   publish-release-docker:
     runs-on: ubuntu-latest
     needs: semantic-release-python
@@ -122,35 +92,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/poglink:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/poglink:${{ needs.semantic-release-python.outputs.package_version}}
-      - name: Push Readme 
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/poglink
-          short-description: ${{ github.event.repository.description }}
-
-  publish-non-release-docker:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    needs: publish-non-release-python
-    steps:
-      - uses: actions/checkout@v2.4.0
-      - name: Set up docker engine 
-        uses: docker/setup-buildx-action@v1
-      - name: Log in to Dockerhub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push 
-        uses: docker/build-push-action@v2 
-        with: 
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:dev
-            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:${{ needs.publish-non-release-python.outputs.package_version || 'dev' }}
       - name: Push Readme 
         uses: peter-evans/dockerhub-description@v2
         with:

--- a/.github/workflows/pub-dev.yml
+++ b/.github/workflows/pub-dev.yml
@@ -1,0 +1,62 @@
+name: Publish Developemnt Version
+on: workflow_dispatch
+jobs:
+  publish-non-release-python:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+        package_version: ${{ steps.set-output-step.outputs.package_version }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0  # https://github.com/pypa/setuptools_scm/issues/480
+      - uses: actions/setup-python@v2.3.1
+        with:  
+          python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: |
+            setup.py
+            requirements.dev.txt
+      - run: pip install -r requirements.dev.txt .
+      - name: Build non-release
+        run: |
+          make python-build
+      - id: set-output-step
+        run: |
+          PACKAGE_VERSION=$(python3 -c 'from setuptools_scm import get_version; print(get_version(local_scheme="no-local-version"))' || echo 0.0.1.dev0)
+          echo "::set-output name=package_version::${PACKAGE_VERSION}"
+      - name: Publish to pypi.org
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          
+  publish-non-release-docker:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: publish-non-release-python
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Set up docker engine 
+        uses: docker/setup-buildx-action@v1
+      - name: Log in to Dockerhub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push 
+        uses: docker/build-push-action@v2 
+        with: 
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:dev
+            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/poglink:${{ needs.publish-non-release-python.outputs.package_version || 'dev' }}
+      - name: Push Readme 
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/poglink
+          short-description: ${{ github.event.repository.description }}
+


### PR DESCRIPTION
Closes #59 

New job should only be triggered manually to avoid unnecessary build time and potentially conflicting dev package version numbers.

Note: It looks like in order to properly test the manual workflow dispatching, we'll actually have to merge this so the workflow [will be available from the Actions tab](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#:~:text=your%20workflow%20must%20be%20in%20the%20default%20branch).