### PR TITLE
feat: parsing for new pve/pvp atlas urls

### DIFF
--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -80,10 +80,10 @@ class Rates(commands.Cog):
 
         # TODO: Add ability to accept custom URL/Title pairs, rather than parsing the DEFAULT_SERVER_INFO list for hardcoded options, then remove this if statement
         if "atlas" in url:
-            if "pve" in url: 
+            if "pve" in url:
                 server_name = "PVE"
-                server_color = 0x63BCC3               
-            else: 
+                server_color = 0x63BCC3
+            else:
                 server_name = "PVP"
                 server_color = 0xA34C44
         else:
@@ -93,12 +93,14 @@ class Rates(commands.Cog):
             )
             if match:
                 server_match_dict = match.groupdict()
-                
+
             else:
                 logger.warning(f"Rates url was not recognized as any known type: {url}")
                 server_match_dict = {}
 
-            server_meta = self.DEFAULT_SERVER_INFO.get(server_match_dict.get("game_mode"))
+            server_meta = self.DEFAULT_SERVER_INFO.get(
+                server_match_dict.get("game_mode")
+            )
             logger.debug(f"Server meta: {server_meta}")
 
             server_name = server_meta.get("short_name")

--- a/poglink/cogs/rates.py
+++ b/poglink/cogs/rates.py
@@ -77,21 +77,32 @@ class Rates(commands.Cog):
     async def send_embed(self, description, url, title=None):
         # generate embed
         logger.debug(f"Attempting to send embed. desc: {description}, url: {url}")
-        match = re.match(
-            r"(?P<host>.*\/)?(?:(?P<platform>.*)\_(?P<game_mode>.*)\_)?dynamicconfig\.ini",
-            os.path.basename(urlparse(url).path),
-        )
-        if match:
-            server_match_dict = match.groupdict()
+
+        # TODO: Add ability to accept custom URL/Title pairs, rather than parsing the DEFAULT_SERVER_INFO list for hardcoded options, then remove this if statement
+        if "atlas" in url:
+            if "pve" in url: 
+                server_name = "PVE"
+                server_color = 0x63BCC3               
+            else: 
+                server_name = "PVP"
+                server_color = 0xA34C44
         else:
-            logger.warning(f"Rates url was not recognized as any known type: {url}")
-            server_match_dict = {}
+            match = re.match(
+                r"(?P<host>.*\/)?(?:(?P<platform>.*)\_(?P<game_mode>.*)\_)?dynamicconfig\.ini",
+                os.path.basename(urlparse(url).path),
+            )
+            if match:
+                server_match_dict = match.groupdict()
+                
+            else:
+                logger.warning(f"Rates url was not recognized as any known type: {url}")
+                server_match_dict = {}
 
-        server_meta = self.DEFAULT_SERVER_INFO.get(server_match_dict.get("game_mode"))
-        logger.debug(f"Server meta: {server_meta}")
-        # TODO: Add ability to accept custom rates URL
+            server_meta = self.DEFAULT_SERVER_INFO.get(server_match_dict.get("game_mode"))
+            logger.debug(f"Server meta: {server_meta}")
 
-        server_name = server_meta.get("short_name")
+            server_name = server_meta.get("short_name")
+            server_color = server_meta.get("color")
 
         if title is None:
             # generate dynamic timestamp (https://hammertime.djdavid98.art/)
@@ -102,7 +113,7 @@ class Rates(commands.Cog):
         embed = discord.Embed(
             description=description,
             title=title,
-            color=server_meta.get("color"),
+            color=server_color,
         )
         embed.set_image(url=EMBED_IMAGE)
 


### PR DESCRIPTION
Hotfix to account for the division of ATLAS endpoints

New endpoints are 
**PVE**: http://atlasdedicated.com/atlas-eu-pve/dynamicconfig.ini
**PVP**: http://atlasdedicated.com/dynamicconfig.ini

Ideally, this should be updated later to just accept a custom endpoint-title pair, that way we don't have to parse the `DEFAULT_SERVER_INFO` dict or do any regex matching for custom scenarios like this.

